### PR TITLE
refactor:  improves type inference for generating operations and models

### DIFF
--- a/example/client/src/lib/mocks/builder.ts
+++ b/example/client/src/lib/mocks/builder.ts
@@ -1,23 +1,10 @@
 import { MockGQLOperations } from '@graphql-mock-operations/core';
-// operation state
-import {
-  UsersOperationState,
-  UserOperationState,
-  BookOperationState,
-  DeleteUserOperationState,
-  CreateUserOperationState,
-} from './operations';
-// models
-import { BookModel, UserModel } from './models';
 import introspectionResult from './introspection.json';
+import { State, Models } from './types';
 
 export interface MockGQLOperationsType {
-  state: BookOperationState &
-    UserOperationState &
-    UsersOperationState &
-    CreateUserOperationState &
-    DeleteUserOperationState;
-  models: BookModel & UserModel;
+  state: State;
+  models: Models;
 }
 
 export const mockBuilder = new MockGQLOperations<MockGQLOperationsType>({

--- a/example/client/src/lib/mocks/models/bookModel.ts
+++ b/example/client/src/lib/mocks/models/bookModel.ts
@@ -1,12 +1,28 @@
 import { mockBuilder } from '../builder';
-import { BookMockOperation } from '../../../typings/generated';
-import { OperationModelType } from '@graphql-mock-operations/core';
 
-export type BookModel = OperationModelType<BookMockOperation>;
-
-mockBuilder.createModel<BookMockOperation>('book', [
-  { id: '1', title: 'Baby Shark', authorId: '3', numPages: 200 },
-  { id: '2', title: 'Mommy Shark', authorId: '2', numPages: 200 },
-  { id: '3', title: 'Daddy Shark', authorId: '1', numPages: 200 },
-  { id: '4', title: 'DeeDee Shark', authorId: '4', numPages: 200 },
+mockBuilder.createModel('book', [
+  {
+    id: '1',
+    title: 'Titan Sinking',
+    authorId: '3',
+    numPages: 200,
+  },
+  {
+    id: '2',
+    title: 'Crimson Dust',
+    authorId: '2',
+    numPages: 200,
+  },
+  {
+    id: '3',
+    title: 'Dawn of Kaus',
+    authorId: '1',
+    numPages: 200,
+  },
+  {
+    id: '4',
+    title: 'Bionic Revelation',
+    authorId: '4',
+    numPages: 200,
+  },
 ]);

--- a/example/client/src/lib/mocks/models/userModel.ts
+++ b/example/client/src/lib/mocks/models/userModel.ts
@@ -1,36 +1,50 @@
 import { mockBuilder } from '../builder';
-import { UserMockOperation } from '../../../typings/generated';
-import { OperationModelType } from '@graphql-mock-operations/core';
 
-export type UserModel = OperationModelType<UserMockOperation>;
-
-mockBuilder.createModel<UserMockOperation>('user', [
+mockBuilder.createModel('user', [
   {
     id: '1',
-    name: 'Frank',
+    name: 'Zirkle Haugen',
     address: [
-      { addressLineOne: '1592 Glen Erin Dr', city: 'Mt Pleasant', state: 'SC', zip: '29464' },
+      {
+        addressLineOne: '100 Baker Ave',
+        city: 'Charleston',
+        state: 'SC',
+        zip: '29412'
+      },
     ],
   },
   {
     id: '2',
-    name: 'Jen',
+    name: 'Ziegler Johnson',
     address: [
-      { addressLineOne: '1592 Glen Erin Dr', city: 'Mt Pleasant', state: 'SC', zip: '29464' },
+      {
+        addressLineOne: '200 Lakeside Dr',
+        city: 'Charleston',
+        state: 'SC', zip: '29412'
+      },
     ],
   },
   {
     id: '3',
-    name: 'Dylan',
+    name: 'Zerbe Evans',
     address: [
-      { addressLineOne: '1592 Glen Erin Dr', city: 'Mt Pleasant', state: 'SC', zip: '29464' },
+      {
+        addressLineOne: '300 Franklin Dr',
+        city: 'Mt Pleasant',
+        state: 'SC',
+        zip: '29464'
+      },
     ],
   },
   {
     id: '4',
-    name: 'Dublin',
+    name: 'Zacharias Wright',
     address: [
-      { addressLineOne: '1592 Glen Erin Dr', city: 'Mt Pleasant', state: 'SC', zip: '29464' },
+      {
+        addressLineOne: '500 Sycamore Ln',
+        city: 'Mt Pleasant',
+        state: 'SC', zip: '29464'
+      },
     ],
   },
 ]);

--- a/example/client/src/lib/mocks/operations/bookOperation.ts
+++ b/example/client/src/lib/mocks/operations/bookOperation.ts
@@ -1,12 +1,17 @@
-import { OperationState } from '@graphql-mock-operations/core';
-import { BookMockOperation } from '../../../typings/generated';
 import { mockBuilder } from '../builder';
 
-export type BookOperationState = OperationState<BookMockOperation, 'SUCCESS' | 'EMPTY' | 'ERROR'>;
-
-mockBuilder.queryOperation<BookMockOperation, BookOperationState>('book', (_, { id }) => [
-  { state: 'SUCCESS', result: ({ book }) => book.findOne('id', id) },
-  { state: 'EMPTY', result: null },
-  { state: 'ERROR', result: { networkError: new Error('failed with 404') } },
+mockBuilder.queryOperation('book', (_, { id }) => [
+  {
+    state: 'SUCCESS',
+    result: ({ book }) => book.findOne('id', id)
+  },
+  {
+    state: 'EMPTY',
+    result: null
+  },
+  {
+    state: 'ERROR',
+    result: { networkError: new Error('failed with 404') }
+  },
 ]);
 

--- a/example/client/src/lib/mocks/operations/createUserOperation.ts
+++ b/example/client/src/lib/mocks/operations/createUserOperation.ts
@@ -1,15 +1,14 @@
 import { mockBuilder } from '../builder';
-import { OperationState } from '@graphql-mock-operations/core';
-import { CreateUserMockOperation } from '../../../typings/generated';
 
-export type CreateUserOperationState = OperationState<CreateUserMockOperation, 'SUCCESS'>;
-
-mockBuilder.mutationOperation<CreateUserMockOperation, CreateUserOperationState>(
+mockBuilder.mutationOperation(
   'createUser',
   (_, { input: { name } }) => [
     {
       state: 'SUCCESS',
-      result: ({ user }) => user.create({ id: String(user.models.length + 1), name }),
+      result: ({ user }) => user.create({
+        id: String(user.models.length + 1),
+        name,
+      }),
     },
   ]
 );

--- a/example/client/src/lib/mocks/operations/deleteUserOperation.ts
+++ b/example/client/src/lib/mocks/operations/deleteUserOperation.ts
@@ -1,12 +1,8 @@
 import { mockBuilder } from '../builder';
-import { DeleteUserMockOperation } from '../../../typings/generated';
-import { OperationState } from '@graphql-mock-operations/core';
 
-export type DeleteUserOperationState = OperationState<DeleteUserMockOperation, 'SUCCESS'>
-
-mockBuilder.mutationOperation<
-  DeleteUserMockOperation,
-  DeleteUserOperationState
->('deleteUser', (_, { id }) => [
-  { state: 'SUCCESS', result: ({ user }) => user.delete('id', id) }
+mockBuilder.mutationOperation('deleteUser', (_, { id }) => [
+  {
+    state: 'SUCCESS',
+    result: ({ user }) => user.delete('id', id)
+  }
 ]);

--- a/example/client/src/lib/mocks/operations/userOperation.ts
+++ b/example/client/src/lib/mocks/operations/userOperation.ts
@@ -1,19 +1,21 @@
 import { mockBuilder } from '../builder';
-import { OperationState } from '@graphql-mock-operations/core';
-import { UserMockOperation } from '../../../typings/generated';
 import { GraphQLError } from 'graphql';
 
-export type UserOperationState = OperationState<
-  UserMockOperation,
-  'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'ERROR'
->;
-
-mockBuilder.queryOperation<
-  UserMockOperation,
-  UserOperationState
->('user', (_, { id }) => [
-  { state: 'SUCCESS', result: ({ user }) => user.findOne('id', id) },
-  { state: 'EMPTY', result: null },
-  { state: 'NETWORK_ERROR', result: { networkError: new Error('network error') } },
-  { state: 'ERROR', result: { graphQLErrors: [new GraphQLError('operation failed')] } }
+mockBuilder.queryOperation('user', (_, { id }) => [
+  {
+    state: 'SUCCESS',
+    result: ({ user }) => user.findOne('id', id)
+  },
+  {
+    state: 'EMPTY',
+    result: null
+  },
+  {
+    state: 'NETWORK_ERROR',
+    result: { networkError: new Error('network error') }
+  },
+  {
+    state: 'ERROR',
+    result: { graphQLErrors: [new GraphQLError('operation failed')] }
+  },
 ])

--- a/example/client/src/lib/mocks/operations/usersOperation.ts
+++ b/example/client/src/lib/mocks/operations/usersOperation.ts
@@ -1,22 +1,21 @@
 import { mockBuilder } from '../builder';
-import { OperationState } from '@graphql-mock-operations/core';
-import { UsersMockOperation } from '../../../typings/generated';
 import { GraphQLError } from 'graphql';
 
-export type UsersOperationState = OperationState<
-  UsersMockOperation,
-  'SUCCESS' | 'ERROR' | 'GQL_ERROR' | 'LOADING'
->;
-
-mockBuilder.queryOperation<UsersMockOperation, UsersOperationState>('users', [
+mockBuilder.queryOperation('users', [
   {
     state: 'SUCCESS',
     result: ({ user }) => user.models,
   },
   {
+    state: 'LOADING',
+    result: { loading: true }
+  },
+  {
+    state: 'ERROR',
+    result: { networkError: new Error('Server responded with 500') }
+  },
+  {
     state: 'GQL_ERROR',
     result: { graphQLErrors: [new GraphQLError('Server responded with 403')] },
   },
-  { state: 'ERROR', result: { networkError: new Error('Server responded with 500') } },
-  { state: 'LOADING', result: { loading: true } },
 ]);

--- a/example/client/src/lib/mocks/types/index.ts
+++ b/example/client/src/lib/mocks/types/index.ts
@@ -1,0 +1,27 @@
+import { OperationModelType, OperationState } from '@graphql-mock-operations/core';
+import {
+  BookMockOperation,
+  CreateUserMockOperation,
+  DeleteUserMockOperation,
+  UserMockOperation,
+  UsersMockOperation
+} from '../../../typings/generated';
+
+// Operation types
+type UsersOperationState = OperationState<UsersMockOperation, 'SUCCESS' | 'ERROR' | 'GQL_ERROR' | 'LOADING'>;
+type UserOperationState = OperationState<UserMockOperation, 'SUCCESS' | 'EMPTY' | 'NETWORK_ERROR' | 'ERROR'>;
+type CreateUserOperationState = OperationState<CreateUserMockOperation, 'SUCCESS'>;
+type DeleteUserOperationState = OperationState<DeleteUserMockOperation, 'SUCCESS'>;
+type BookOperationState = OperationState<BookMockOperation, 'SUCCESS' | 'EMPTY' | 'ERROR'>;
+
+// Model types
+type UserModel = OperationModelType<UserMockOperation>;
+type BookModel = OperationModelType<BookMockOperation>;
+
+export type State = UsersOperationState
+  & UserOperationState
+  & CreateUserOperationState
+  & DeleteUserOperationState
+  & BookOperationState;
+
+export type Models = UserModel & BookModel;

--- a/example/client/src/routes/Users/UserCard.tsx
+++ b/example/client/src/routes/Users/UserCard.tsx
@@ -8,7 +8,7 @@ interface UserCardProps {
 }
 
 export const UserCard: React.FC<UserCardProps> = ({ user }) => {
-  const { deleteUser, loading } = useDeleteUser({
+  const { deleteUser, loading, error } = useDeleteUser({
     update: (cache, { data }) => {
       const result = data?.deleteUser;
       if (!result) return;
@@ -41,6 +41,7 @@ export const UserCard: React.FC<UserCardProps> = ({ user }) => {
         <code>{JSON.stringify(user, null, 2)}</code>
       </pre>
       <button onClick={handleDeleteUser}>{loading ? 'Loading...' : `Delete ${user.name}`}</button>
+      {error && <span>{JSON.stringify(error, null, 2)}</span>}
     </div>
   );
 };

--- a/example/client/src/stories/Users.stories.tsx
+++ b/example/client/src/stories/Users.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { StoryWithApollo } from '@graphql-mock-operations/storybook-addon';
 import { Users } from '../routes/Users';
-import { MockProvider, models } from '../lib/mocks';
+import { MockProvider } from '../lib/mocks';
 
 export default {
   title: 'Example/Users',
@@ -17,8 +17,17 @@ Primary.args = {
 };
 Primary.parameters = {
   apolloClient: {
-    operationState: { book: 'SUCCESS', createUser: 'SUCCESS' },
-    mergeOperations: { users: () => [models.user.models[2]] },
+    operationState: {
+      book: 'SUCCESS',
+      createUser: 'SUCCESS',
+      user: 'SUCCESS',
+      users: 'GQL_ERROR',
+      deleteUser: 'SUCCESS'
+    },
+    mergeOperations: ({ user, book }) => ({
+      users: () => [user.models[3]],
+      book: () => book.findOne('id', '3'),
+    }),
     delay: 1200,
   },
 };

--- a/packages/core/src/OperationModel.ts
+++ b/packages/core/src/OperationModel.ts
@@ -39,7 +39,7 @@ export class OperationModel<TModel extends OperationType<any, any>> {
   };
 
   findLast = (): ResolverReturn<ReturnType<TModel[keyof TModel]>> =>
-    this._models[this._models.length - 1];
+    this._models[this._models?.length - 1];
 
   create = (
     model: ResolverReturn<ReturnType<TModel[keyof TModel]>>
@@ -56,14 +56,14 @@ export class OperationModel<TModel extends OperationType<any, any>> {
     data: Partial<ResolverReturn<ReturnType<TModel[keyof TModel]>>>
   ): ResolverReturn<ReturnType<TModel[keyof TModel]>> => {
     const models = this._models.filter((model) => model[key] === value);
-    if (models.length > 1) {
+    if (models?.length > 1) {
       // eslint-disable-next-line no-console
       console.warn(
         'update model: more than one model found. Please provide a unique key/value pair for improved results.'
       );
     }
 
-    if (models.length === 0) {
+    if (models?.length === 0) {
       throw new Error('update model: model not found. Please provide a unique key/value pair.');
     }
 

--- a/packages/core/src/utils/createMockLink.ts
+++ b/packages/core/src/utils/createMockLink.ts
@@ -48,7 +48,7 @@ export function createMockLink(
           const originalError = result?.errors?.[0].originalError as ApolloError;
           if (originalError) {
             const { graphQLErrors, networkError } = originalError ?? {};
-            graphQLErrors.length && observer.next({ errors: result?.errors });
+            graphQLErrors?.length && observer.next({ errors: result?.errors });
             networkError ? observer.error(networkError) : observer.error(originalError.message);
           } else {
             observer.next(result);

--- a/packages/storybook-addon/src/components/Decorator.tsx
+++ b/packages/storybook-addon/src/components/Decorator.tsx
@@ -54,7 +54,7 @@ export const WithApolloClient = (Story: FC<unknown>): JSX.Element => {
           {
             ...operationMeta,
             operationName,
-            operationCount: existingOperation.length,
+            operationCount: existingOperation?.length,
           },
         ];
       }

--- a/packages/storybook-addon/src/components/Panel.tsx
+++ b/packages/storybook-addon/src/components/Panel.tsx
@@ -57,7 +57,7 @@ export const Panel = ({ active = false, key }: RenderOptions): React.ReactElemen
                   {activeMeta.query}
                 </SyntaxHighlighter>
               </PanelCard>
-              {Object.keys(activeMeta.variables).length > 0 && (
+              {Object.keys(activeMeta.variables)?.length > 0 && (
                 <PanelCard>
                   <PanelTitle>Variables</PanelTitle>
                   <SyntaxHighlighter language="json" copyable bordered padded>


### PR DESCRIPTION
- Improved type inference - allows consumers no longer need to provide generics for operation and model creations
- exposes models to the `mergeOperations` method
- various updates to the example